### PR TITLE
Update relation keyword

### DIFF
--- a/grammars/graql.cson
+++ b/grammars/graql.cson
@@ -561,7 +561,7 @@ repository:
         name: 'support.type.entity.graql'
       }
       {
-        match: '(\\"relationship\\")|(\\brelationship\\b)'
+        match: '(\\"relation\\")|(\\brelation\\b)'
         name: 'support.type.relationship.graql'
       }
       {


### PR DESCRIPTION
According to the Grakn.ai documentation (https://dev.grakn.ai/docs/schema/concepts), the keyword `relation` is used instread of `relationship`. Updating the keyword so `relation` will be highlighted.